### PR TITLE
User friend error on M00_prerequisites

### DIFF
--- a/software/metax/Exceptions.py
+++ b/software/metax/Exceptions.py
@@ -1,0 +1,28 @@
+
+class ReportableException(Exception):
+    """Simple exeception with message"""
+    def __init__(self, msg):
+        self.msg = msg
+
+class InvalidInputFormat(ReportableException):
+    """Error associated with input format"""
+    def __init__(self, msg):
+        super(InvalidInputFormat, self).__init__("Invalid input format: %s" % (msg))
+
+class InvalidOutputFormat(ReportableException):
+    """Error associated with input format"""
+    def __init__(self, msg):
+        super(InvalidOutputFormat, self).__init__("Invalid output format: %s" % (msg))
+
+
+class BadFilename(ReportableException):
+    """Reports invalid filename"""
+
+    def __init__(self, filename):
+        super(BadFilename, self).__init__("Invalid filename: %s" % (filename))
+
+class BadDirectory(ReportableException):
+    """Reports non-existnant directory"""
+
+    def __init__(self, dir):
+        super(BadDirectory, self).__init__("Invalid directory: %s" % (dir))

--- a/software/metax/Utilities.py
+++ b/software/metax/Utilities.py
@@ -1,6 +1,7 @@
 __author__ = 'heroico'
 
 import os
+import Exceptions
 
 VALID_ALLELES = ["A", "T", "C", "G"]
 
@@ -35,18 +36,20 @@ def namesWithPatternFromFolder(folder, pattern):
     return names
 
 def contentsWithPatternsFromFolder(folder, patterns):
-    contents = os.listdir(folder)
-    paths = []
-    for content in contents:
-        matches = True
-        for pattern in patterns:
-            if not pattern in content:
-                matches = False
-                break
+    try:
+        contents = os.listdir(folder)
+        paths = []
+        for content in contents:
+            matches = True
+            for pattern in patterns:
+                if not pattern in content:
+                    matches = False
+                    break
 
-        if matches:
-            paths.append(content)
-
+            if matches:
+                paths.append(content)
+    except OSError:
+        raise Exceptions.BadDirectory(folder)
     return paths
 
 def contentsWithRegexpFromFolder(folder, regexp):

--- a/software/metax/__init__.py
+++ b/software/metax/__init__.py
@@ -1,1 +1,5 @@
-__version__ = "0.2.1"
+__version__ = "0.2.2"
+
+def exitIf(doExit, Exception, msg):
+    if doExit:
+        raise Exception(msg)


### PR DESCRIPTION
Added a couple of checks that prevent previous stack dumps and now report more user friendly error messages. I also changed a handful of assertions to force exit to provide a single point of exit via exceptions. Finally, to catch invalid input and output formatters, I switched the argparse type to choice. I left the error handling in (with modifications mentioned above) in case there are ever any additional additions to the choice list. 