### PR TITLE
Clarified error when covariance contains SNPs that aren't present in the weights database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,7 @@
 
 # Python's setuptools stuff
 *dist/
-*.egg-info
-*.egg
+*.egg*
 setuptools*.zip
 
 # PyCharm project files

--- a/software/M04_zscores.py
+++ b/software/M04_zscores.py
@@ -44,7 +44,7 @@ class CalculateZScores(object):
                 people = Person.Person.loadPeople(samples_path)
                 people_by_id = {p.id:p for p in people}
 
-        logging.info("Loading weight db")
+        logging.info("Loading weights from database: %s" % (self.weight_db_path))
         weight_db_logic = WeightDBUtilities.WeightDBEntryLogic(self.weight_db_path)
 
         results = None
@@ -97,6 +97,7 @@ class CalculateZScores(object):
                 valid_rsids = entry[1]
 
                 logging.log(7, "Calculating z score for %s", gene)
+
                 pre_zscore, n, VAR_g = zscore_calculation(gene, weights, beta_sets, covariance_matrix, valid_rsids)
                 results[gene] = self.buildEntry(gene, weight_db_logic, weights, pre_zscore, n, VAR_g)
                 i+=1

--- a/software/metax/MatrixUtilities.py
+++ b/software/metax/MatrixUtilities.py
@@ -41,7 +41,8 @@ def loadMatrixFromFile(file):
 
             the_gene = self.pending[0][0]
             if the_gene in self.entries:
-                raise Exceptions.MalformedInputFile(file, "Snp Covariance Entries for genes must be contiguous but %s was found in two different places in the file." % (the_gene))
+                raise Exceptions.MalformedInputFile(file,
+                        "Snp Covariance Entries for genes must be contiguous but %s was found in two different places in the file." % (the_gene))
 
             key_filter = {}
             valid_keys = []

--- a/software/metax/ZScoreCalculation.py
+++ b/software/metax/ZScoreCalculation.py
@@ -3,6 +3,7 @@ __author__ = 'heroico'
 import logging
 import numpy
 import math
+import Exceptions
 
 
 BETA_Z = "beta_z"
@@ -158,6 +159,8 @@ def preProcess(covariance_matrix, valid_rsids, weights, beta_sets):
     weight_values = []
     variances = {}
     for i,rsid in enumerate(valid_rsids):
+        if rsid not in weights:
+            raise Exceptions.ReportableException("RSID %s can't be found in the weights database. Are you sure your covariance data matches the weights database you are using?" % (rsid))
         weight = weights[rsid].weight
         if b and (not rsid in b.values_by_key or b.values_by_key[rsid] == "NA"):
             logging.log(7, "snp %s not present in beta data, skipping weight")

--- a/software/tests/test_M00_prerequisites.py
+++ b/software/tests/test_M00_prerequisites.py
@@ -56,7 +56,9 @@ class TestM00(unittest.TestCase):
         self.assertEqual(p.snp_list, "_test/snp.txt.gz")
         self.assertEqual(p.output_folder, "_test/intermediate/filtered")
         self.assertEqual(p.population_group_filters, ["HERO"])
-        self.assertEqual(p.individual_filters, [re.compile("ID.*")])
+        # Previous check below looked at memory locations, which failed under
+        # some conditions even though the expressions were effectively identical
+        self.assertEqual([x.pattern for x in p.individual_filters], ["ID.*"])
         self.assertEqual(p.chromosome_in_name_regex,re.compile("set_(.*)"))
         self.assertEqual(p.samples_input, "_test/dosage_set_1/set.sample")
         self.assertEquals(p.samples_output, "_test/intermediate/filtered/set.sample")
@@ -90,3 +92,6 @@ class TestM00(unittest.TestCase):
                 actual_line = f.readline().strip()
                 self.assertEqual(actual_line, expected_line)
         cleanUpDataForArgs("_test")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Raise exception indicating that a particular SNP was missing from the weights database. Also clarified tests for the individual_filters so that they test the pattern and not the memory address