### PR TITLE
Added skip-until-header to support the requirements from GWAS Utilities

### DIFF
--- a/software/MetaMany.py
+++ b/software/MetaMany.py
@@ -160,8 +160,12 @@ if __name__ == "__main__":
     parser.add_argument("--separator",
                         help="Character or string separating fields in input file. Defaults to any whitespace.",
                         default=None)
+    parser.add_argument("--skip_until_header",
+                        help="Some files may be malformed and contain unespecified bytes in the beggining."
+                             " Specify this option (string value) to identify a header up to which file contents should be skipped.",
+                        default=None)
 
-#both
+    #both
 
     parser.add_argument("--beta_folder",
                         help="name of folder to put beta parsing results in",


### PR DESCRIPTION
This had been unintentionally left out of the original version and it's absence causes errors under certain circumstances. 