### PR TITLE
Changes to make program more forgiving for changes to the tissue data…

### DIFF
--- a/software/CHANGES
+++ b/software/CHANGES
@@ -1,3 +1,8 @@
+Version 0.3.1
+    * Various changes to MetaMany.py: 
+        * Better flexibility for database organization. 
+        * Result files are now named GWAS-TISSUE to make them easier to identify
+        * Betas are stored inside the output directory 
 Version 0.3
     * New Transcriptome Model (Weight DBs) format support. Formalized Metaxcan output handling, added new fields to output (effect size, model prediction qvalue, etc)
 Version 0.2.6

--- a/software/MetaMany.py
+++ b/software/MetaMany.py
@@ -208,7 +208,7 @@ arguments --covariance_directory and --covariance_suffix. """)
 
     parser.add_argument("--covariance_directory",
                         help="directory where covariance files can be found (or SAME if covariance sits beside the .db file",
-                        default="intermediate/cov")
+                        default="SAME")
 
     parser.add_argument("--covariance_suffix",
                         help="Suffix associated with the covariate files. covext-dbext (where ..dbext is the portion of the db file to be replaced by the coviarance extention. )",

--- a/software/metax/__init__.py
+++ b/software/metax/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.3"
+__version__ = "0.3.1"
 
 def exitIf(doExit, Exception, msg):
     if doExit:


### PR DESCRIPTION
users can now choose "SAME" for covariance database if their covariances are located in the same directory as the corresponding tissue database. Also, the user can now specify the spelling of the file suffix for the covariance file (and what it will be replacing in the database filename) to properly handle the subtle differences in filenames. 