### PR TITLE
Minor correction to final output filename

### DIFF
--- a/software/MetaMany.py
+++ b/software/MetaMany.py
@@ -111,8 +111,7 @@ class MetaXcanProcess(object):
                 pass
 
         suffix = ".csv"
-        if args.compressed:
-            suffix += ".gz"
+
         self.args.output_file = os.path.join(output_folder,
                                              report_prefix + "-" + file_prefix + suffix)  # output_folder       #os.path.join(output_folder, file_prefix) + ".csv"
 


### PR DESCRIPTION
Previously, I believed the final result would be compressed with with gzip after calling m04 when --compress flag was active, but that was not the case. My filename was therefore incorrectly suggesting that the file was gzipped. I have removed the addition of the .gz extension to avoid the confusion. 