### PR TITLE
The previous fix doesn't work for gwas without intersection to models…

### DIFF
--- a/software/metax/gwas/GWAS.py
+++ b/software/metax/gwas/GWAS.py
@@ -105,7 +105,7 @@ def load_gwas(source, gwas_format, strict=True, sep='\s+'):
     if strict:
         d = _ensure_columns(d)
         d = _keep_gwas_columns(d)
-        if numpy.any(~ numpy.isfinite(d[ZSCORE])):
+        if d.shape[0] >0 and numpy.any(~ numpy.isfinite(d[ZSCORE])):
             logging.warning("Some GWAS snp zscores are not finite.")
 
     return d


### PR DESCRIPTION
…. This ensures that it runs successfully even if no results are to be calculated.