### PR TITLE
M03_betas.py output filepath logic

### DIFF
--- a/software/M03_betas.py
+++ b/software/M03_betas.py
@@ -103,9 +103,10 @@ def run(args):
     model = PredictionModel.load_model(args.model_db_path, args.model_db_snp_key) if args.model_db_path else None
 
     if args.output_folder or args.output:
-        if args.output_folder and not os.path.exists(args.output_folder):
-            os.makedirs(args.output_folder)
-        elif args.output:
+        if args.output_folder:
+            if args.output_folder and not os.path.exists(args.output_folder):
+                os.makedirs(args.output_folder)
+        else:
             Utilities.ensure_requisite_folders(args.output)
 
         for i,name in enumerate(names):

--- a/software/M03_betas.py
+++ b/software/M03_betas.py
@@ -105,7 +105,7 @@ def run(args):
     if args.output_folder or args.output:
         if args.output_folder and not os.path.exists(args.output_folder):
             os.makedirs(args.output_folder)
-        else:
+        elif args.output:
             Utilities.ensure_requisite_folders(args.output)
 
         for i,name in enumerate(names):


### PR DESCRIPTION
When running `software/M03_betas.py` and specifying `--output_folder` with a pre-existing directory, the script forces a check on the `--output` parameter. This isn't good, because both `--output_folder` and `--output` cannot both be specified. 