### PR TITLE
Fix issue 112

### DIFF
--- a/software/Predict.py
+++ b/software/Predict.py
@@ -156,8 +156,6 @@ def run(args):
 
     logging.info("Loading samples")
     samples = load_samples(args)
-    if args.vcf_mode == 'haplotyped':
-        samples = pandas.concat((samples.apply(lambda x: x + '_h1'), samples.apply(lambda x: x + '_h2')), axis=0).reset_index(drop=True)
 
     logging.info("Loading model")
     model, weights, extra = model_structure(args)
@@ -171,7 +169,6 @@ def run(args):
     dcapture = []
     reporter = Utilities.PercentReporter(logging.INFO, len(set(weights.rsid.values)))
     snps_found = set()
-    nploid = 1 if args.vcf_mode == 'haplotyped' else 2  # ploidy is 1 when doing one haplotype at a time
     with prepare_prediction(args, extra, samples) as results:
 
         for i,e in enumerate(dosage_source):
@@ -190,7 +187,7 @@ def run(args):
 
                 dosage = e[GF.FIRST_DOSAGE:]
                 if allele_align == -1:
-                    dosage = tuple(map(lambda x: nploid - x, dosage))
+                    dosage = tuple(map(lambda x: 2 - x, dosage))
                 dosage = numpy.array(dosage, dtype=numpy.float)
 
                 snps_found.add(var_id)

--- a/software/Predict.py
+++ b/software/Predict.py
@@ -156,6 +156,8 @@ def run(args):
 
     logging.info("Loading samples")
     samples = load_samples(args)
+    if args.vcf_mode == 'haplotyped':
+        samples = pandas.concat((samples.apply(lambda x: x + '_h1'), samples.apply(lambda x: x + '_h2')), axis=0)
 
     logging.info("Loading model")
     model, weights, extra = model_structure(args)
@@ -169,6 +171,7 @@ def run(args):
     dcapture = []
     reporter = Utilities.PercentReporter(logging.INFO, len(set(weights.rsid.values)))
     snps_found = set()
+    nploid = 1 if args.vcf_mode == 'haplotyped' else 2  # ploidy is 1 when doing one haplotype at a time
     with prepare_prediction(args, extra, samples) as results:
 
         for i,e in enumerate(dosage_source):
@@ -187,7 +190,7 @@ def run(args):
 
                 dosage = e[GF.FIRST_DOSAGE:]
                 if allele_align == -1:
-                    dosage = tuple(map(lambda x: 2 - x, dosage))
+                    dosage = tuple(map(lambda x: nploid - x, dosage))
                 dosage = numpy.array(dosage, dtype=numpy.float)
 
                 snps_found.add(var_id)

--- a/software/Predict.py
+++ b/software/Predict.py
@@ -171,7 +171,11 @@ def run(args):
     snps_found = set()
     with prepare_prediction(args, extra, samples) as results:
 
-        for i,e in enumerate(dosage_source):
+        for contents in enumerate(dosage_source):
+            if isinstance(contents, RuntimeError):
+                raise contents
+            else:
+                i, e = contents
             if args.stop_at_variant and i>args.stop_at_variant:
                 break
             var_id = e[GF.RSID]

--- a/software/Predict.py
+++ b/software/Predict.py
@@ -171,11 +171,9 @@ def run(args):
     snps_found = set()
     with prepare_prediction(args, extra, samples) as results:
 
-        for contents in enumerate(dosage_source):
-            if isinstance(contents, RuntimeError):
-                raise contents
-            else:
-                i, e = contents
+        for i,e in enumerate(dosage_source):
+            if isinstance(e, RuntimeError):
+                raise e
             if args.stop_at_variant and i>args.stop_at_variant:
                 break
             var_id = e[GF.RSID]

--- a/software/Predict.py
+++ b/software/Predict.py
@@ -157,7 +157,7 @@ def run(args):
     logging.info("Loading samples")
     samples = load_samples(args)
     if args.vcf_mode == 'haplotyped':
-        samples = pandas.concat((samples.apply(lambda x: x + '_h1'), samples.apply(lambda x: x + '_h2')), axis=0)
+        samples = pandas.concat((samples.apply(lambda x: x + '_h1'), samples.apply(lambda x: x + '_h2')), axis=0).reset_index(drop=True)
 
     logging.info("Loading model")
     model, weights, extra = model_structure(args)

--- a/software/metax/genotype/CYVCF2Genotype.py
+++ b/software/metax/genotype/CYVCF2Genotype.py
@@ -63,9 +63,9 @@ def vcf_file_geno_lines(path, mode="genotyped", variant_mapping=None, whitelist=
                 f = numpy.mean(numpy.array(d)) / 2
                 yield (variant_id, chr, pos, ref, alt, f) + tuple(d)
             except KeyError:
-                yield RuntimeError("VCF mode was selected to be imputed but do not have DS field in the VCF.")
+                yield RuntimeError("Missing DS field when vcf mode is imputed")
         else:
-            yield RuntimeError("Unsupported vcf mode")
+            yield RuntimeError(f"Unsupported vcf mode = {mode}")
 
 
 def vcf_files_geno_lines(files, mode="genotyped", variant_mapping=None, whitelist=None, skip_palindromic=False, liftover_conversion=None):

--- a/software/metax/genotype/CYVCF2Genotype.py
+++ b/software/metax/genotype/CYVCF2Genotype.py
@@ -57,12 +57,15 @@ def vcf_file_geno_lines(path, mode="genotyped", variant_mapping=None, whitelist=
 
             if whitelist and variant_id not in whitelist:
                 continue
-
-            d = numpy.apply_along_axis(lambda x: x[0], 1, variant.format("DS"))
-            f = numpy.mean(numpy.array(d)) / 2
-            yield (variant_id, chr, pos, ref, alt, f) + tuple(d)
+            
+            try:
+                d = numpy.apply_along_axis(lambda x: x[0], 1, variant.format("DS"))
+                f = numpy.mean(numpy.array(d)) / 2
+                yield (variant_id, chr, pos, ref, alt, f) + tuple(d)
+            except KeyError:
+                yield RuntimeError("VCF mode was selected to be imputed but do not have DS field in the VCF.")
         else:
-            raise RuntimeError("Unsupported vcf mode")
+            yield RuntimeError("Unsupported vcf mode")
 
 
 def vcf_files_geno_lines(files, mode="genotyped", variant_mapping=None, whitelist=None, skip_palindromic=False, liftover_conversion=None):

--- a/software/metax/genotype/CYVCF2Genotype.py
+++ b/software/metax/genotype/CYVCF2Genotype.py
@@ -61,33 +61,6 @@ def vcf_file_geno_lines(path, mode="genotyped", variant_mapping=None, whitelist=
             d = numpy.apply_along_axis(lambda x: x[0], 1, variant.format("DS"))
             f = numpy.mean(numpy.array(d)) / 2
             yield (variant_id, chr, pos, ref, alt, f) + tuple(d)
-        
-        elif mode == 'haplotyped':
-            if len(alts) > 1:
-                logging.log("VCF haplotyped mode doesn't support multiple ALTs, skipping %s", variant_id)
-                continue
-            alt = alts[0]
-            a = 0
-            
-            if skip_palindromic and Genomics.is_palindromic(ref, alt):
-                continue
-
-            _varid, variant_id = Genomics.maybe_map_variant(variant_id, chr, pos, ref, alt, variant_mapping, is_dict_mapping)
-            if variant_id is None: continue
-
-            if whitelist and variant_id not in whitelist:
-                continue
-
-            d1 = []  # haplotype1
-            d2 = []  # haplotype2
-            for sample in variant.genotypes:
-                d1_ = sample[0] == a+1
-                d2_ = sample[1] == a+1
-                d1.append(d1_)
-                d2.append(d2_)
-            f = numpy.mean(numpy.array(d1,dtype=numpy.int32) + numpy.array(d2,dtype=numpy.int32))/2
-            yield (variant_id, chr, pos, ref, alt, f) + tuple(d1) + tuple(d2)
-            
         else:
             raise RuntimeError("Unsupported vcf mode")
 

--- a/software/metax/genotype/CYVCF2Genotype.py
+++ b/software/metax/genotype/CYVCF2Genotype.py
@@ -61,6 +61,33 @@ def vcf_file_geno_lines(path, mode="genotyped", variant_mapping=None, whitelist=
             d = numpy.apply_along_axis(lambda x: x[0], 1, variant.format("DS"))
             f = numpy.mean(numpy.array(d)) / 2
             yield (variant_id, chr, pos, ref, alt, f) + tuple(d)
+        
+        elif mode == 'haplotyped':
+            if len(alts) > 1:
+                logging.log("VCF haplotyped mode doesn't support multiple ALTs, skipping %s", variant_id)
+                continue
+            alt = alts[0]
+            a = 0
+            
+            if skip_palindromic and Genomics.is_palindromic(ref, alt):
+                continue
+
+            _varid, variant_id = Genomics.maybe_map_variant(variant_id, chr, pos, ref, alt, variant_mapping, is_dict_mapping)
+            if variant_id is None: continue
+
+            if whitelist and variant_id not in whitelist:
+                continue
+
+            d1 = []  # haplotype1
+            d2 = []  # haplotype2
+            for sample in variant.genotypes:
+                d1_ = sample[0] == a+1
+                d2_ = sample[1] == a+1
+                d1.append(d1_)
+                d2.append(d2_)
+            f = numpy.mean(numpy.array(d1,dtype=numpy.int32) + numpy.array(d2,dtype=numpy.int32))/2
+            yield (variant_id, chr, pos, ref, alt, f) + tuple(d1) + tuple(d2)
+            
         else:
             raise RuntimeError("Unsupported vcf mode")
 

--- a/software/metax/predixcan/Utilities.py
+++ b/software/metax/predixcan/Utilities.py
@@ -276,7 +276,12 @@ class BasicPredictionRepository(PredictionRepository):
 
     def summary(self):
         return summary_report(self.stats, self.extra)
-
+    
+    def __enter__(self):
+        pass
+        
+    def __exit__(self, exc_type, exc_value, traceback):
+        pass
 
 class HDF5PredictionRepository(PredictionRepository):
     def __init__(self, samples, extra, path):


### PR DESCRIPTION
This PR is related to #112 

Added explicit handling of wrong VCF mode in two cases. 

1. Users specify wrong `vcf_mode` (anything other than `genotyped` or `imputed`). 

Previously, the software will run through without error messages. 

Now, it will raise an error like: `INFO - Unexpected error: Unsupported vcf mode = [the-wrong-mode]`.

2. Users specify `vcf_mode = imputed` but no `DS` field in input VCF file.

Previously, the software will run through without error messages.

Now, it will raise an error like: `INFO - Unexpected error: Missing DS field when vcf mode is imputed`.
