### PR TITLE
Re-enable text prediction

### DIFF
--- a/software/metax/predixcan/Utilities.py
+++ b/software/metax/predixcan/Utilities.py
@@ -250,7 +250,7 @@ class PredictionRepository:
         return self
 
     def __exit__(self, type, value, traceback):
-        return self
+        pass
 
 class BasicPredictionRepository(PredictionRepository):
     def __init__(self, samples, extra, output_path):
@@ -277,8 +277,8 @@ class BasicPredictionRepository(PredictionRepository):
     def summary(self):
         return summary_report(self.stats, self.extra)
     
-    # def __enter__(self):
-    #     pass
+    def __enter__(self):
+        return self
         
     def __exit__(self, exc_type, exc_value, traceback):
         pass


### PR DESCRIPTION
@liangyy I think this change will re-enable text-based predictions in `Predict.py` and `PrediXcan.py`