### PR TITLE
Update vcf file processing

### DIFF
--- a/software/metax/genotype/CYVCF2Genotype.py
+++ b/software/metax/genotype/CYVCF2Genotype.py
@@ -44,8 +44,8 @@ def vcf_file_geno_lines(path, mode="genotyped", variant_mapping=None, whitelist=
                 yield (variant_id, chr, pos, ref, alt, f) + tuple(d)
 
         elif mode == "imputed":
-            if len(alts[0]) > 1:
-                logging.log("VCF imputed mode doesn't support multiple ALTs, skipping %s", variant_id)
+            if (len(ref)) | (len(alts[0])) > 1:
+                logging.log("VCF imputed mode doesn't support multiple REFs or ALTs, skipping %s", variant_id)
                 continue
 
             alt = alts[0]

--- a/software/metax/genotype/CYVCF2Genotype.py
+++ b/software/metax/genotype/CYVCF2Genotype.py
@@ -8,7 +8,7 @@ from metax.misc import Genomics
 
 def vcf_file_geno_lines(path, mode="genotyped", variant_mapping=None, whitelist=None, skip_palindromic=False, liftover_conversion=None):
     logging.log(9, "Processing vcf %s", path)
-    vcf_reader = VCF(path)
+    vcf_reader = VCF(path, gts012=True)
 
     is_dict_mapping = variant_mapping is not None and type(variant_mapping) == dict
 

--- a/software/metax/genotype/CYVCF2Genotype.py
+++ b/software/metax/genotype/CYVCF2Genotype.py
@@ -40,7 +40,7 @@ def vcf_file_geno_lines(path, mode="genotyped", variant_mapping=None, whitelist=
                 for sample in variant.genotypes:
                     d_ = (sample[0] == a+1) + (sample[1] == a+1)
                     d.append(d_)
-                f = numpy.mean(numpy.array(d,dtype=numpy.int32))/2
+                f = numpy.nanmean(numpy.array(d,dtype=numpy.int32))/2
                 yield (variant_id, chr, pos, ref, alt, f) + tuple(d)
 
         elif mode == "imputed":
@@ -60,7 +60,7 @@ def vcf_file_geno_lines(path, mode="genotyped", variant_mapping=None, whitelist=
             
             try:
                 d = numpy.apply_along_axis(lambda x: x[0], 1, variant.format("DS"))
-                f = numpy.mean(numpy.array(d)) / 2
+                f = numpy.nanmean(numpy.array(d)) / 2
                 yield (variant_id, chr, pos, ref, alt, f) + tuple(d)
             except KeyError:
                 yield RuntimeError("Missing DS field when vcf mode is imputed")

--- a/software/metax/genotype/CYVCF2Genotype.py
+++ b/software/metax/genotype/CYVCF2Genotype.py
@@ -44,7 +44,7 @@ def vcf_file_geno_lines(path, mode="genotyped", variant_mapping=None, whitelist=
                 yield (variant_id, chr, pos, ref, alt, f) + tuple(d)
 
         elif mode == "imputed":
-            if len(alts) > 1:
+            if len(alts[0]) > 1:
                 logging.log("VCF imputed mode doesn't support multiple ALTs, skipping %s", variant_id)
                 continue
 

--- a/software/metax/genotype/CYVCF2Genotype.py
+++ b/software/metax/genotype/CYVCF2Genotype.py
@@ -45,7 +45,7 @@ def vcf_file_geno_lines(path, mode="genotyped", variant_mapping=None, whitelist=
 
         elif mode == "imputed":
             if (len(ref)) | (len(alts[0])) > 1:
-                logging.log("VCF imputed mode doesn't support multiple REFs or ALTs, skipping %s", variant_id)
+                logging.log(8, "VCF imputed mode doesn't support multiple REFs or ALTs, skipping %s", variant_id)
                 continue
 
             alt = alts[0]


### PR DESCRIPTION
I made some edits to get Predict.py running on UK Biobank data converted to VCF format. Note, I used plink2 to convert bgen to vcf with the modifer 'vcf-dosage=DS-force'. Otherwise, dosages were missing from genotyped variants if I used 'vcf-dosage=DS'. 