### PR TITLE
SprediXcan variance control for inflation

### DIFF
--- a/software/SPrediXcan.py
+++ b/software/SPrediXcan.py
@@ -39,7 +39,8 @@ if __name__ == "__main__":
     parser.add_argument("--model_db_snp_key", help="Specify a key to use as snp_id")
 #GWAS betas
     parser.add_argument("--gwas_file", help="Load a single GWAS file. (Alternative to providing a gwas_folder and gwas_file_pattern)")
-
+    parser.add_argument("--gwas_h2", help="GWAS heritability (h2)", type=float, default=None, required=False)
+    parser.add_argument("--gwas_N", help="GWAS sample size (N)", type=int, default=None, required=False)
     parser.add_argument("--gwas_folder", help="name of folder containing GWAS data. All files in the folder are assumed to belong to a single study.")
     parser.add_argument("--gwas_file_pattern", help="Pattern to recognice GWAS files in folders (in case there are extra files and you don't want them selected).")
 
@@ -60,6 +61,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     Logging.configureLogging(int(args.verbosity))
+
+    if args.gwas_h2 is None or args.gwas_N is None:
+        logging.warning("Missing --gwas_h2 and --gwas_N are required to calibrate the pvalue and zscore.")
 
     if args.throw:
         run(args)

--- a/software/metax/Logging.py
+++ b/software/metax/Logging.py
@@ -13,9 +13,20 @@ def configureLogging(level=5, target=sys.stderr):
         logger.handlers.clear()
 
     # create console handler and set level to info
+    RED = "\033[91m"
+    RESET = "\033[0m"
+
+    # A custom logging formatter for warning
+    class CustomFormatter(logging.Formatter):
+        def format(self, record):
+            if record.levelno == logging.WARNING:
+                record.msg = f"{RED}{record.msg}{RESET}"
+            return super().format(record)
+
+    # create console handler and set level to info
     handler = logging.StreamHandler(target)
     handler.setLevel(level)
-    formatter = logging.Formatter("%(levelname)s - %(message)s")
+    formatter = CustomFormatter("%(levelname)s - %(message)s")
     handler.setFormatter(formatter)
     logger.addHandler(handler)
 


### PR DESCRIPTION
Updated code base to calibrate the pvalues and zscores from SPrediXcan using the variance control method. The method uses phi, N and h2. Phi is provided in the models and the user must provide the h2 and N from the summary statistics.